### PR TITLE
Show where your virtualdom layer has mistakenly used an object

### DIFF
--- a/debugCSS.css
+++ b/debugCSS.css
@@ -1003,3 +1003,7 @@ body > img:only-child {
   margin: 1em auto;
   padding: 0;
 }
+
+*[style="[object Object]"] {
+  outline: 5px solid #8F8;
+}


### PR DESCRIPTION
Not sure if I did this right, but basically I see a few people who have "virtualDOM" layers that accidentally printed the object of the style instead of a string. This catches those issues, since it's a silent bug.