### PR TITLE
Changing the structure README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
-License
----
-Copyrights for code authored by Yahoo! Inc. is licensed under the following terms:
+
+# debugCSS: (X)HTML debugging tool built with CSS
+
+debugCSS is meant to be loaded on an existing page to highlight potentially broken, malformed or legacy (X)HTML.
+
+Not all "errors" are created equally, so they are color coded to highlight severity.  Green is "probably not a big problem", yellow is "worth looking at" and red is "you really should fix this."
+
+Each condition is specified in three areas:
+- Setting up the :after area for display (trying to reset common styles like colors, font sizes, etc).
+- Specifying the color severity (green, yellow, red) and content (which is the error or warning message to be displayed).
+- Creating the outline around the offending element according to it's color severity.
+
+## Install
+
+Visit [http://imbrianj.github.com/debugCSS/](http://imbrianj.github.com/debugCSS/) to install the bookmarklet.
+
+## License
+
+Copyrights for code authored by Yahoo! Inc. is licensed under the following terms: 
 MIT License
 Copyright (c) 2011 Yahoo! Inc. All Rights Reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-What is this?
----
-debugCSS is meant to be loaded on an existing page to highlight potentially broken, malformed or legacy (X)HTML.
-
-Not all "errors" are created equally, so they are color coded to highlight severity.  Green is "probably not a big problem", yellow is "worth looking at" and red is "you really should fix this."
-
-About
----
-Each condition is specified in three areas:
-
-  - Setting up the :after area for display (trying to reset common styles like colors, font sizes, etc).
-  - Specifying the color severity (green, yellow, red) and content (which is the error or warning message to be displayed).
-  - Creating the outline around the offending element according to it's color severity.
-
-Install
----
-Visit [http://imbrianj.github.com/debugCSS/](http://imbrianj.github.com/debugCSS/) to install the bookmarklet.


### PR DESCRIPTION
First, it's using the markdown syntax.

The second is to add the title of the project (to make it clearer that this is). After that, two unnecessary headers were deleted (because the text is small, they are not particularly useful).

Finally, the transfer of the text about the license to the end of the file (again for greater readability).